### PR TITLE
Fix build errors and remove dashboard routes

### DIFF
--- a/src/app/(modules)/layout.tsx
+++ b/src/app/(modules)/layout.tsx
@@ -1,8 +1,7 @@
 import { Metadata } from "next"
 import { RolesProvider } from "@/lib/hooks/use-roles"
 import { Toaster } from "@/components/ui/toaster"
-import { header as Header } from "@/components/header"
-import { SideNav as Sidebar } from "@/components/side-nav"
+import { SideNav } from "@/components/side-nav"
 
 export const metadata: Metadata = {
   title: "Schoolgle - Dashboard",
@@ -17,9 +16,42 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <RolesProvider>
       <div className="flex h-screen overflow-hidden">
-        <Sidebar />
+        <SideNav items={[
+          {
+            href: "/",
+            title: "Dashboard",
+          },
+          {
+            href: "/teaching",
+            title: "Teaching",
+          },
+          {
+            href: "/send",
+            title: "SEND",
+          },
+          {
+            href: "/finance",
+            title: "Finance",
+          },
+          {
+            href: "/estates",
+            title: "Estates",
+          },
+          {
+            href: "/hr",
+            title: "HR",
+          },
+          {
+            href: "/reports",
+            title: "Reports",
+          },
+        ]} />
         <div className="flex-1 overflow-y-auto">
-          <Header />
+          <header className="sticky top-0 z-40 border-b bg-background">
+            <div className="container flex h-16 items-center justify-between py-4">
+              <h2 className="text-lg font-semibold">Schoolgle</h2>
+            </div>
+          </header>
           <main className="container mx-auto p-6">{children}</main>
         </div>
       </div>

--- a/src/lib/hooks/use-roles.ts
+++ b/src/lib/hooks/use-roles.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { createContext, useContext, useState } from "react"
 
 type Role = "admin" | "teacher" | "staff" | "student" | "parent"
@@ -9,7 +11,14 @@ interface RolesContextType {
   removeRole: (role: Role) => void
 }
 
-const RolesContext = createContext<RolesContextType | undefined>(undefined)
+const defaultContext: RolesContextType = {
+  roles: [],
+  hasRole: () => false,
+  addRole: () => {},
+  removeRole: () => {},
+}
+
+export const RolesContext = createContext<RolesContextType>(defaultContext)
 
 export function RolesProvider({ children }: { children: React.ReactNode }) {
   const [roles, setRoles] = useState<Role[]>([])
@@ -27,7 +36,14 @@ export function RolesProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <RolesContext.Provider value={{ roles, hasRole, addRole, removeRole }}>
+    <RolesContext.Provider
+      value={{
+        roles,
+        hasRole,
+        addRole,
+        removeRole,
+      }}
+    >
       {children}
     </RolesContext.Provider>
   )


### PR DESCRIPTION
This PR fixes several build errors:

1. Removes all dashboard routes to resolve the routing conflict:
   - Removed `src/app/dashboard/page.tsx`
   - Removed `src/app/dashboard/layout.tsx`
   - Removed `src/app/(modules)/dashboard/page.tsx`

2. Fixes TypeScript errors in `use-roles.ts`:
   - Added proper type definitions
   - Fixed context provider syntax
   - Added default context value

3. Updates layout imports:
   - Now correctly imports `SideNav` from `side-nav.tsx`
   - Removed header component in favor of inline header
   - Added navigation items to `SideNav`

4. Moves dashboard functionality to modules root:
   - Added `src/app/(modules)/page.tsx` as the main landing page
   - Keeps all protected routes under the modules group

These changes should resolve all build errors and maintain the application's functionality.